### PR TITLE
replace TextStylePropType to PropTypes.object so Jest tests pass

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -11,13 +11,11 @@ var {
   ProgressBarAndroid,
   Platform
 } = React;
-var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
-var TextStylePropTypes = require('react-native/Libraries/Text/TextStylePropTypes');
 
 var Button = React.createClass({
   propTypes: Object.assign({},
     TouchableOpacity.propTypes,
-    {textStyle: StyleSheetPropType(TextStylePropTypes),
+    {textStyle: PropTypes.object,
     children: PropTypes.string.isRequired,
     isLoading: PropTypes.bool,
     isDisabled: PropTypes.bool,


### PR DESCRIPTION
In my project, [https://github.com/bartonhammond/snowflake](https://github.com/bartonhammond/snowflake) I use react-native-button and perform many Jest tests against my components.

Because Button.js has this reference shown below, Jest testing fails.  Making this minor change, Jest tests pass while the app is not effected.

Currently my project references my github repository and I'd rather they all used yours as this is a minor change.  

```
var StyleSheetPropType = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
var TextStylePropTypes = require('react-native/Libraries/Text/TextStylePropTypes');
```

-barton
