### PR TITLE
let the container to control the layout of its children

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -123,7 +123,6 @@ var styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     marginBottom: 10,
-    alignSelf: 'stretch',
     justifyContent: 'center',
   },
   textButton: {


### PR DESCRIPTION
When I use several Buttons as the children of a container. I cannot just control the layout by just setting `alignItems: 'center'` on the container. So I checked the source code I found it would be better if the default `alignSelf` were dropped. So I did it. It's just a progress not a bug.