### PR TITLE
Fixes #14. Children, if present, are required to be of type string, node, or element.

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var   React = require('react-native');
 var {
   View,
   TouchableOpacity,
@@ -18,7 +18,11 @@ var Button = React.createClass({
     {
       textStyle: Text.propTypes.style,
       disabledStyle: Text.propTypes.style,
-      children: PropTypes.string.isRequired,
+      children: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.node,
+        React.PropTypes.element
+      ]),
       isLoading: PropTypes.bool,
       isDisabled: PropTypes.bool,
       activityIndicatorColor: PropTypes.string,

--- a/Button.js
+++ b/Button.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var   React = require('react-native');
+var React = require('react-native');
 var {
   View,
   TouchableOpacity,


### PR DESCRIPTION
Fixes #14
Children aren't required - so an empty button is allowed, but if they are present they must be of types:

```javascript
        React.PropTypes.string,
        React.PropTypes.node,
        React.PropTypes.element
```

This should allow nesting of custom elements (icons) inside buttons. This is a more accommodating fix than what was presenting in code by #15 and seems to line up more with @alvaromb's desires for this change.

Here's a screenshot of the proposed solution working with react-native-vector-icons:

<img width="216" alt="screen shot 2016-04-30 at 10 40 34 am" src="https://cloud.githubusercontent.com/assets/1033728/14936649/1e5e1d14-0ec0-11e6-9648-4f9aa78ea6a1.png">

And here's the code for the button:

```jsx
<Button style={styles.button} textStyle={styles.buttonText}>
    <Text>WAT</Text>
    {pizzaIcon}
    <Text> WAT 2 </Text>
</Button>
```