### PR TITLE
For the button to add the activeOpacity attribute interface

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -20,6 +20,7 @@ var Button = React.createClass({
       disabledStyle: Text.propTypes.style,
       children: PropTypes.string.isRequired,
       activeOpacity: PropTypes.number,
+      allowFontScaling: PropTypes.bool,
       isLoading: PropTypes.bool,
       isDisabled: PropTypes.bool,
       activityIndicatorColor: PropTypes.string,
@@ -66,7 +67,7 @@ var Button = React.createClass({
       );
     }
     return (
-      <Text style={[styles.textButton, this.props.textStyle]}>
+      <Text style={[styles.textButton, this.props.textStyle]} allowFontScaling={this.props.allowFontScaling}>
         {this.props.children}
       </Text>
     );

--- a/Button.js
+++ b/Button.js
@@ -19,6 +19,7 @@ var Button = React.createClass({
       textStyle: Text.propTypes.style,
       disabledStyle: Text.propTypes.style,
       children: PropTypes.string.isRequired,
+      activeOpacity: PropTypes.number,
       isLoading: PropTypes.bool,
       isDisabled: PropTypes.bool,
       activityIndicatorColor: PropTypes.string,
@@ -91,7 +92,8 @@ var Button = React.createClass({
         onPress: this.props.onPress,
         onPressIn: this.props.onPressIn,
         onPressOut: this.props.onPressOut,
-        onLongPress: this.props.onLongPress
+        onLongPress: this.props.onLongPress,
+        activeOpacity: this.props.activeOpacity,
       };
       if (Button.isAndroid) {
         touchableProps = Object.assign(touchableProps, {

--- a/Example/button/Example.js
+++ b/Example/button/Example.js
@@ -3,6 +3,12 @@ import Button from 'apsl-react-native-button'
 
 export default class Example extends React.Component {
   render () {
+    var onPressProps;
+    if(this.state.isOnPressing) {
+      onPressProps = styles.buttonStylePressing
+    } else {
+      onPressProps = styles.buttonStyle1
+    }
     return (
       <View style={styles.container}>
         <Button
@@ -14,10 +20,12 @@ export default class Example extends React.Component {
           Hello
         </Button>
         <Button
-          style={styles.buttonStyle1} textStyle={styles.textStyle}
-          onPress={() => {
-            console.log('world!')
-          }}>
+          textStyle={styles.textStyle}
+          style={onPressProps}
+          activeOpacity={1}
+          isOnPressing={this.state.isOnPressing}
+          onPressIn={() => this.onPressIn()}
+          onPressOut={() => this.onPressOut()}>
           Hello
         </Button>
         <Button
@@ -93,6 +101,10 @@ const styles = StyleSheet.create({
     color: '#8e44ad',
     fontFamily: 'Avenir',
     fontWeight: 'bold'
+  },
+  buttonStylePressing: {
+    borderColor: 'red',
+    backgroundColor: 'red'
   },
   buttonStyle: {
     borderColor: '#f39c12',

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ and disable it to prevent accidental taps.
 | ``children`` | ``string`` | The ``string`` to render as the text button. |
 | ``isLoading`` | ``bool`` | Renders an inactive state dimmed button with a spinner if ``true``. |
 | ``isDisabled`` | ``bool`` | Renders an inactive state dimmed button if ``true``. |
+| ``activeOpacity`` | ``Number`` | The button onpressing transparency (Usually with a point value between 0 and 1). |
 | ``activityIndicatorColor`` | ``string`` | Sets the button of the ``ActivityIndicatorIOS`` or ``ProgressBarAndroid`` in the loading state. |
 | ``background`` | ``TouchableNativeFeedback.propTypes.background`` | **Android only**. The background prop of ``TouchableNativeFeedback``. |
-
 Check the included example for more options.
 
 ## Similar projects


### PR DESCRIPTION
For the button to add the activeOpacity attribute interface, let the button click effect is more flexible.
Example of the second button Add the attribute test.
Add a description of the property the Readme.md.