### PR TITLE
Fix renderable children

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -22,7 +22,11 @@ const Button = React.createClass({
   propTypes: {
     textStyle: Text.propTypes.style,
     disabledStyle: Text.propTypes.style,
-    children: PropTypes.string.isRequired,
+    children: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node,
+        PropTypes.element
+      ]),
     activeOpacity: PropTypes.number,
     allowFontScaling: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -41,6 +45,26 @@ const Button = React.createClass({
   statics: {
     isAndroid: (Platform.OS === 'android'),
   },
+  
+  _renderChildren: function() {
+    var childElements = [];
+      React.Children.forEach(this.props.children, (item) => {
+        if (typeof item === 'string' || typeof item === 'number') {
+          var element = (
+              <Text 
+                style={[styles.textButton, this.props.textStyle]}
+                allowFontScaling={this.props.allowFontScaling}
+                key={item}>
+                {item}
+              </Text>
+            );
+          childElements.push(element);
+        } else if (React.isValidElement(item)) {
+          childElements.push(item);
+        }
+      });
+    return (childElements);
+  },
 
   _renderInnerTextAndroid: function () {
     if (this.props.isLoading) {
@@ -54,11 +78,7 @@ const Button = React.createClass({
         />
       );
     }
-    return (
-      <Text style={[styles.textButton, this.props.textStyle]}>
-        {this.props.children}
-      </Text>
-    );
+    return this._renderChildren();
   },
 
   _renderInnerTextiOS: function () {
@@ -72,11 +92,7 @@ const Button = React.createClass({
         />
       );
     }
-    return (
-      <Text style={[styles.textButton, this.props.textStyle]} allowFontScaling={this.props.allowFontScaling}>
-        {this.props.children}
-      </Text>
-    );
+    return this._renderChildren();
   },
 
   shouldComponentUpdate: function (nextProps, nextState) {

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ and disable it to prevent accidental taps.
 </Button>
 ```
 
+You can also provide a `<Button>` element with nested children that are not strings
+or `<Text>` elements as long as they are valid React elements or numbers. This helps
+if your project is using another library that provides easy icon integration 
+utilizing the `<i>` tag, for instance, as well as various other cases where you are
+creating visually complex buttons. You may omit the `textStyle` property and apply
+your own styles to your child elements as you see fit. Multiple children are allowed.
+
+```javascript
+<Button style={{backgroundColor: 'blue'}}>
+  <View style={styles.nestedViewStyle}>
+    <Text style={styles.nestedTextStyle}>Nested views!</Text>
+  </View>
+</Button>
+```
+
 ## API
 
 | Prop | Type | Description |
@@ -49,7 +64,7 @@ and disable it to prevent accidental taps.
 | ``onLongPress`` | ``func`` | Function to execute when the ``onLongPress`` event is triggered. |
 | ``textStyle`` | ``TextStylePropTypes`` | The StyleSheet to apply to the inner button text. |
 | ``disabledStyle`` | ``TextStylePropTypes`` | The StyleSheet to apply when disabled. |
-| ``children`` | ``string`` | The ``string`` to render as the text button. |
+| ``children`` | ``string``, ``number``, ``React.Element``,or ``array`` | The child nodes to render inside the button. If child is ``string`` or ``number``, it will be rendered inside of a ``<Text>`` element with ``textStyle`` applied if present. Multiple children are allowed (``array``).|
 | ``isLoading`` | ``bool`` | Renders an inactive state dimmed button with a spinner if ``true``. |
 | ``isDisabled`` | ``bool`` | Renders an inactive state dimmed button if ``true``. |
 | ``activeOpacity`` | ``Number`` | The button onpressing transparency (Usually with a point value between 0 and 1). |


### PR DESCRIPTION
This PR loosens the requirements on children and allows any number of elements nested inside a button as long as they're either a string, or valid react elements.

The button `textStyle` property is optional and only applied to bare strings. If you specify child elements that are of `<Text>` type, you'll want to specify your own style on that `<Text>` element. This keeps the original functionality but expands upon it for further customization.