### PR TITLE
Fix "touchableProps" is read-only

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -99,7 +99,7 @@ const Button = React.createClass({
       );
     } else {
       // Extract Touchable props
-      const touchableProps = {
+      let touchableProps = {
         onPress: this.props.onPress,
         onPressIn: this.props.onPressIn,
         onPressOut: this.props.onPressOut,


### PR DESCRIPTION
Changing const touchableProps to let touchableProps.
=> Object.assign on #109 causes otherwise error "touchableProps" is read-only