### PR TITLE
fix Button.js: put an undefined-check for TouchableNativeFeedback

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -34,7 +34,7 @@ const Button = React.createClass({
     onLongPress: PropTypes.func,
     onPressIn: PropTypes.func,
     onPressOut: PropTypes.func,
-    background: (TouchableNativeFeedback.propTypes) ? TouchableNativeFeedback.propTypes.background : PropTypes.any,
+    background: (TouchableNativeFeedback && TouchableNativeFeedback.propTypes) ? TouchableNativeFeedback.propTypes.background : PropTypes.any,
   },
 
   statics: {


### PR DESCRIPTION
Context:
I'm using "react-native-web" & "react-native-gifted-form" which has "APSL/react-native-button" as a dependency.
I think because in web mode, TouchableNativeFeedback is undefined, it crashed my app.

I just added an undefined-check for TouchableNativeFeedback.
Please merge. Thanks.

![image](https://cloud.githubusercontent.com/assets/639189/20855378/5b1bc9ae-b8b1-11e6-8a65-0ceddc31e195.png)
