### PR TITLE
used es6 export

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -148,4 +148,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = Button;
+export default Button;


### PR DESCRIPTION
Used es6 export to specify explicit default export. This allows import intellisense for IDEs such as webstorm. 