### PR TITLE
Remove marginBottom in button style

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -130,7 +130,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderWidth: 1,
     borderRadius: 8,
-    marginBottom: 10,
     alignSelf: 'stretch',
     justifyContent: 'center',
   },


### PR DESCRIPTION
The reason is that we cannot set `marginVertical` style for the button as the `marginBottom` will always override it. The component uses Button have to define both `marginBottom` and `marginTop` instead. Thus I think we should let let the one use it define the margin.

Thanks for the library!