### PR TITLE
Feature: Button with TouchableOpacity for Android

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -40,6 +40,8 @@ class Button extends Component {
     touchFeedBackType: PropTypes.oneOf(['nativeFeedback', 'opacity'])
   }
 
+  static touchFeedBackTypes = ['nativeFeedback', 'opacity']
+
   static isAndroid = (Platform.OS === 'android')
 
   _renderChildren() {

--- a/Button.js
+++ b/Button.js
@@ -108,7 +108,7 @@ class Button extends Component {
       delayPressIn: this.props.delayPressIn,
       delayPressOut: this.props.delayPressOut,
     };
-    if (Button.isAndroid) {
+    if (Button.isAndroid && touchFeedBackType === 'nativeFeedback') {
       touchableProps = Object.assign(touchableProps, {
         background: this.props.background || TouchableNativeFeedback.SelectableBackground()
       });

--- a/Button.js
+++ b/Button.js
@@ -37,6 +37,7 @@ class Button extends Component {
     onPressIn: PropTypes.func,
     onPressOut: PropTypes.func,
     background: (TouchableNativeFeedback.propTypes) ? TouchableNativeFeedback.propTypes.background : PropTypes.any,
+    touchFeedBackType: PropTypes.oneOf(['nativeFeedback', 'opacity'])
   }
 
   static isAndroid = (Platform.OS === 'android')

--- a/Button.js
+++ b/Button.js
@@ -86,6 +86,8 @@ class Button extends Component {
   }
 
   render() {
+    let { touchFeedBackType } = this.props
+    touchFeedBackType = Button.touchFeedBackTypes.includes(touchFeedBackType) ? touchFeedBackType : 'nativeFeedback'
     if (this.props.isDisabled === true || this.props.isLoading === true) {
       return (
         <View style={[styles.button, this.props.style, (this.props.disabledStyle || styles.opacity)]}>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ your own styles to your child elements as you see fit. Multiple children are all
 | ``children`` | ``string``, ``number``, ``React.Element``,or ``array`` | The child nodes to render inside the button. If child is ``string`` or ``number``, it will be rendered inside of a ``<Text>`` element with ``textStyle`` applied if present. Multiple children are allowed (``array``).|
 | ``isLoading`` | ``bool`` | Renders an inactive state dimmed button with a spinner if ``true``. |
 | ``isDisabled`` | ``bool`` | Renders an inactive state dimmed button if ``true``. |
+| ``touchFeedBackType`` | ``string`` | Accepted values ``nativeFeedback``, ``opacity``. Default value ``nativeFeedback``, if value is  ``nativeFeedback`` then button is rendered  using ``TouchableNativeFeedBack`` else if value is ``opacity`` then button is rendered using ``TouchableOpacity`` (**Only for Android**) |
 | ``activeOpacity`` | ``Number`` | The button onpressing transparency (Usually with a point value between 0 and 1). |
 | ``activityIndicatorColor`` | ``string`` | Sets the button of the ``ActivityIndicatorIOS`` or ``ProgressBarAndroid`` in the loading state. |
 | ``background`` | ``TouchableNativeFeedback.propTypes.background`` | **Android only**. The background prop of ``TouchableNativeFeedback``. |


### PR DESCRIPTION
For:  #80

1. Defined prop ``touchFeedBackType`` type String and accepted values are `nativeFeedback``, ``opacity``
2. If value is  ``nativeFeedback`` then button is rendered  using ``TouchableNativeFeedBack`` else if value is ``opacity`` then button is rendered using ``TouchableOpacity``
3. Default value is ``nativeFeedback``
